### PR TITLE
Verb Dial's parameter onEnd renamed to onConnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ project/build/target
 target
 .DS_Store
 scwilio.properties
+.classpath
+.project
+.scala_dependencies

--- a/core/src/main/scala/scwilio/twiml/TwiML.scala
+++ b/core/src/main/scala/scwilio/twiml/TwiML.scala
@@ -32,7 +32,7 @@ object TwiML {
 
     case dial: Dial =>
        <Dial callerId={dial.from.toStandardFormat}
-             action={dial.onEnd.getOrElse("")}
+             action={dial.onConnect.getOrElse("")}
              timeout={dial.timeout.toString}>{dial.to.toStandardFormat}</Dial>
 
     case conf: ConnectToConference =>

--- a/core/src/main/scala/scwilio/twiml/verbs.scala
+++ b/core/src/main/scala/scwilio/twiml/verbs.scala
@@ -25,7 +25,7 @@ object Verb {
 case class Dial(
    from: Phonenumber,
    to: Phonenumber,
-   onEnd: Option[String] = None,
+   onConnect: Option[String] = None,
    timeout: Int = 30
  ) extends Verb
 


### PR DESCRIPTION
The TwiML unit test was failing to compile because verb Dial was being passed a parameter "onConnect", whereas Dial expected an "onEnd" parameter.  I have changed Dial to accept "onConnect" paramter to be consistent with the README documentation.
