### PR TITLE
No longer print optional parameters.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ scwilio.properties
 .classpath
 .project
 .scala_dependencies
+.target

--- a/core/src/main/scala/scwilio/twiml/TwiML.scala
+++ b/core/src/main/scala/scwilio/twiml/TwiML.scala
@@ -14,6 +14,16 @@ object TwiML {
     </Response>
   }
 
+  private implicit def optInt2optString(v: Option[Int]): Option[String] = v match {
+    case Some(i) => Some(i.toString)
+    case _ => None
+  }
+
+  private def optional(v: Option[String]): Option[xml.Text] = v match {
+    case Some(s) => Some(new xml.Text(s))
+    case _ => None
+  }
+
   def apply(verb: Verb) : Node = verb match {
     case say: Say =>
        <Say voice={say.voice.value} loop={say.loop.toString} language={say.language.value}>{say.what}</Say>
@@ -32,22 +42,23 @@ object TwiML {
 
     case dial: Dial =>
        <Dial callerId={dial.from.toStandardFormat}
-             action={dial.onConnect.getOrElse("")}
-             timeout={dial.timeout.toString}>{dial.to.toStandardFormat}</Dial>
+             action={optional(dial.onConnect)}
+             timeout={optional(dial.timeout)}>{dial.to.toStandardFormat}</Dial>
 
     case conf: ConnectToConference =>
-      <Dial action={conf.onLeave.getOrElse("")}>
-        <Conference waitUrl={conf.onWait.getOrElse("")}
+      <Dial action={optional(conf.onLeave)}>
+        <Conference waitUrl={optional(conf.onWait)}
           muted={conf.muted.toString}
           startConferenceOnEnter={conf.startOnEnter.toString}
           endConferenceOnExit={conf.endOnExit.toString}>{conf.cid}</Conference>
       </Dial>
+
     case gather: Gather =>
-        <Gather action={gather.onGathered.getOrElse("")}
+        <Gather action={optional(gather.onGathered)}
                 finishOnKey={gather.finishOnKey.toString}
                 numDigits={gather.numDigits.toString} timeout={gather.timeout.toString}/>
+
     case redirect: Redirect =>
         <Redirect>{redirect.to}</Redirect>
   }
-
 }

--- a/core/src/main/scala/scwilio/twiml/verbs.scala
+++ b/core/src/main/scala/scwilio/twiml/verbs.scala
@@ -26,7 +26,7 @@ case class Dial(
    from: Phonenumber,
    to: Phonenumber,
    onConnect: Option[String] = None,
-   timeout: Int = 30
+   timeout: Option[Int] = None
  ) extends Verb
 
 /**

--- a/core/src/test/scala/scwilio/twiml/TwiMLSpec.scala
+++ b/core/src/test/scala/scwilio/twiml/TwiMLSpec.scala
@@ -8,7 +8,22 @@ import scala.xml._
 object TwiMLSpec extends Specification {
 
   "TwiML" should {
-    "generate correct XML for a VoiceResponse" in {
+
+    "generate correct XML for Dial verb" in { 
+      val r = Dial(from = Phonenumber("+1999"), to = Phonenumber("+1888"))
+      val ml = XML.loadString(TwiML(r).toString) // reload XML to remove whitespace
+      val expected = XML.loadString("""<Dial callerId="+1999">+1888</Dial>""")
+      ml must_== expected
+    }
+
+    "generate correct XML for Dial verb - with action url" in { 
+      val r = Dial(from = Phonenumber("+1999"), to = Phonenumber("+1888"), onConnect=Some("http://url"))
+      val ml = XML.loadString(TwiML(r).toString) // reload XML to remove whitespace
+      val expected = XML.loadString("""<Dial action="http://url" callerId="+1999">+1888</Dial>""")
+      ml must_== expected
+    }
+
+    "generate correct XML for a complex VoiceResponse" in {
       val r = VoiceResponse(
           Say("Hello, world"),
           Pause(),
@@ -18,7 +33,6 @@ object TwiMLSpec extends Specification {
           ConnectToConference("cid", Some("http://callback"), Some("http://wait"), muted = false, startOnEnter = false, endOnExit = false ),
           Gather(timeout = 30, finishOnKey = '*', numDigits = 4, onGathered = Some("http://digits")),
           Redirect("http://foo.com/")
-
       )
 
       val ml = TwiML(r)
@@ -29,15 +43,13 @@ object TwiMLSpec extends Specification {
            <Pause length="1"/>
            <Play loop="1">http://foo.com/cowbell.mp3</Play>
            <Say voice="man" language="en" loop="1">Goodbye</Say>
-           <Dial callerId="+1999" action="http://test" timeout="30">+1888</Dial>
+           <Dial callerId="+1999" action="http://test">+1888</Dial>
            <Dial action="http://callback">
              <Conference waitUrl="http://wait" muted="false" startConferenceOnEnter="false" endConferenceOnExit="false">cid</Conference>
            </Dial>
            <Gather action="http://digits" finishOnKey="*" numDigits="4" timeout="30"/>
            <Redirect>http://foo.com/</Redirect>
         </Response>)
-
     }
   }
-
 }


### PR DESCRIPTION
No longer print optional parameters. For instance, the "action" attribute of
<Dial> should only be present if it provides a valid URL. Having a blank/empty
"action" attribute to <Dial> leads to a Twilio error when the dialed party
hangs up. This changeset fixes the issue of having such blank/empty attributes.
