### PR TITLE
Added code to handle "action" attribute of <Dial> verb

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,7 +31,7 @@ To generate some TwiML, put this in a handler of whatever web framework your're 
                Pause(10),
                Play("http://foo.com/cowbell.mp3"),
                Say("Dialing 8 8 8 8"),
-               Dial(from = Phonenumber("+1999"), to = Phonenumber("+1888"), onConnect = Some("http://test"))
+               Dial(from = Phonenumber("+1999"), to = Phonenumber("+1888"), onEnd = Some("http://test"))
              )
     val stringResponse = TwiML(response).toString
     // Write the response

--- a/core/src/main/scala/scwilio/callback/callbackmanager.scala
+++ b/core/src/main/scala/scwilio/callback/callbackmanager.scala
@@ -6,7 +6,8 @@ import scwilio.twiml._
 object functions {
   type CallbackFunc[T <: CallbackEvent, R] = (T) => R
   type ActiveCallFunc = (ActiveCall) => VoiceResponse
-  type DialOutcomeFunc = (CompletedCall) => Unit
+  type CallOutcomeFunc = (CompletedCall) => Unit
+  type OutgoingDialOutcomeFunc = (CompletedOutgoingDial) => VoiceResponse
 
   // TODO: This is a hack. Used for waitUrl in ConnectToConfernce (which gives no params)
   // Should have a noop or CID-only callback

--- a/core/src/main/scala/scwilio/devices.scala
+++ b/core/src/main/scala/scwilio/devices.scala
@@ -58,4 +58,14 @@ trait Phone { self: CallbackManager with Logging =>
     }
   }
 
+  /**
+   * Callback when an outgoing dial (i.e., via <Dial/>) call ends.
+   */
+  def handleOutgoingDialEnded(fid: String, outcome: CompletedOutgoingDial) : VoiceResponse = {
+    log.debug("Outgoing dial ended: " + outcome)
+    getAndRemove[CompletedOutgoingDial, VoiceResponse](fid) match {
+      case Some(callback) => callback.apply(outcome)
+      case _ => Say("Sorry, an error has occured. Do not know how to handle this call.")
+    }
+  }
 }

--- a/core/src/main/scala/scwilio/twiml/TwiML.scala
+++ b/core/src/main/scala/scwilio/twiml/TwiML.scala
@@ -34,7 +34,7 @@ object TwiML {
 
     case dial: Dial =>
        <Dial callerId={dial.from.toStandardFormat}
-             action={optional(dial.onConnect)}
+             action={optional(dial.onEnd)}
              timeout={dial.timeout.toString}>{dial.to.toStandardFormat}</Dial>
 
     case conf: ConnectToConference =>

--- a/core/src/main/scala/scwilio/twiml/verbs.scala
+++ b/core/src/main/scala/scwilio/twiml/verbs.scala
@@ -25,7 +25,7 @@ object Verb {
 case class Dial(
    from: Phonenumber,
    to: Phonenumber,
-   onConnect: Option[String] = None,
+   onEnd: Option[String] = None,
    timeout: Int = 30
  ) extends Verb
 

--- a/core/src/test/scala/scwilio/twiml/TwiMLSpec.scala
+++ b/core/src/test/scala/scwilio/twiml/TwiMLSpec.scala
@@ -17,7 +17,7 @@ object TwiMLSpec extends Specification {
     }
 
     "generate correct XML for Dial verb - with action url" in { 
-      val r = Dial(from = Phonenumber("+1999"), to = Phonenumber("+1888"), onConnect=Some("http://url"))
+      val r = Dial(from = Phonenumber("+1999"), to = Phonenumber("+1888"), onEnd = Some("http://url"))
       val ml = XML.loadString(TwiML(r).toString) // reload XML to remove whitespace
       val expected = XML.loadString("""<Dial action="http://url" callerId="+1999" timeout="30">+1888</Dial>""")
       ml must_== expected
@@ -29,7 +29,7 @@ object TwiMLSpec extends Specification {
           Pause(),
           Play("http://foo.com/cowbell.mp3"),
           Say("Goodbye"),
-          Dial(from = Phonenumber("+1999"), to = Phonenumber("+1888"), onConnect = Some("http://test")),
+          Dial(from = Phonenumber("+1999"), to = Phonenumber("+1888"), onEnd = Some("http://test")),
           ConnectToConference("cid", Some("http://callback"), Some("http://wait"), muted = false, startOnEnter = false, endOnExit = false ),
           Gather(timeout = 30, finishOnKey = '*', numDigits = 4, onGathered = Some("http://digits")),
           Redirect("http://foo.com/")


### PR DESCRIPTION
As I just recently needed to use the "action" attribute to get the duration of an outgoing call initiated via <Dial>, I realized that Scwilio didn't have proper support for it. 

This pull request remedies it.
